### PR TITLE
Updated broken link for elastic search

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Ahmia search engine use elasticsearch to index content.
 
 ## Installation
-Please install elastic search from the official repository thanks to the [official guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/_installation.html))
+Please install elastic search from the official repository thanks to the [official guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/_installation.html)
 
 ## Configuration
 Default configuration is enough to run index in dev mode. Here is suggestion for a more secure configuration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Ahmia search engine use elasticsearch to index content.
 
 ## Installation
-Please install elastic search from the official repository thanks to the [official guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-repositories.html)
+Please install elastic search from the official repository thanks to the [official guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/_installation.html))
 
 ## Configuration
 Default configuration is enough to run index in dev mode. Here is suggestion for a more secure configuration


### PR DESCRIPTION
While setting up my development environment for Ahmia-Index, I notice that the link posted for installing elastic search gives my a 403 error. So I decided to update to help others install Ahmia-Index as well.