### PR TITLE
Update gather_from_index.py

### DIFF
--- a/gather_from_index.py
+++ b/gather_from_index.py
@@ -6,7 +6,8 @@ import settings  # Import the settings from settings.py
 ALLOWED_DOMAINS = [
     "donionsixbjtiohce24abfgsffo2l4tk26qx464zylumgejukfq2vead.onion",
     "deeeepv4bfndyatwkdzeciebqcwwlvgqa6mofdtsvwpon4elfut7lfqd.onion",
-    "juhanurmihxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion"
+    "juhanurmihxlp77nkq76byazcldy2hlmovfu2epvl5ankdibsot4csyd.onion",
+    "torgolnpeouim56dykfob6jh5r2ps2j73enc42s2um4ufob3ny4fcdyd.onion"
 ]
 
 def search(es, domain_list, keywords_list):


### PR DESCRIPTION
Update whitelist to include Torgol search engine url from filtering. I noticed it got banned by keyword filter. it's a search engine and does not hosts csam. 